### PR TITLE
fix uint32_t*<->size_t* mismatch

### DIFF
--- a/Patcher.cpp
+++ b/Patcher.cpp
@@ -847,7 +847,7 @@ Status PatchContext::ReplaceReferencesToGlobal(
 static void CopyInstructions(
   uint8**   ppWriter,
   cs_insn*  pInsns,
-  size_t*   pCount,
+  uint32_t*   pCount,
   uint8*    pOverwrittenSize,
   uint8     offsetLut[MaxOverwriteSize])
 {
@@ -856,7 +856,7 @@ static void CopyInstructions(
 
   uint8*const  pBegin     = *ppWriter;
   size_t  curOldOffset    = 0;
-  size_t  count           = *pCount;
+  uint32_t  count           = *pCount;
   uint8   overwrittenSize = *pOverwrittenSize;
   bool    foundEnd        = false;
   std::vector<std::pair<uint32*, uint8>> deferredRelocs;


### PR DESCRIPTION
probably doesn't make a difference at runtime, but my compiler (MinGW-W64 g++) refused to compile it in 64bit:

```
Patcher.cpp: In function 'Patcher::Status Patcher::CreateTrampoline(void*, void**, void**, uint8*, size_t*, size_t, uint8*)':
Patcher.cpp:1089:40: error: cannot convert 'Patcher::uint32*' {aka 'unsigned int*'} to 'size_t*' {aka 'long long unsigned int*'}
 1089 |     CopyInstructions(&pWriter, pInsns, &oldCount, &overwrittenSize, offsetLut);
      |                                        ^~~~~~~~~
      |                                        |
      |                                        Patcher::uint32* {aka unsigned int*}
Patcher.cpp:854:13: note:   initializing argument 3 of 'void Patcher::CopyInstructions(uint8**, cs_insn*, size_t*, uint8*, uint8*)'
  854 |   size_t*   pCount,
      |   ~~~~~~~~~~^~~~~~
```